### PR TITLE
Use DOM events instead of React events

### DIFF
--- a/packages/keyboard-shortcuts/src/channel/Hooks.tsx
+++ b/packages/keyboard-shortcuts/src/channel/Hooks.tsx
@@ -34,28 +34,30 @@ export function useElementsThatStopKeyboardEventsPropagation(
   element: HTMLElement | Window = window,
   selectors: string[]
 ) {
-  const stopPropagation = (ev: KeyboardEvent) => {
-    ev.stopPropagation();
-  };
+  useEffect(() => {
+    const stopPropagation = (ev: KeyboardEvent) => {
+      ev.stopPropagation();
+    };
 
-  const target = element === window ? document : (element as HTMLElement);
-  const elementsStoppingPropagation = selectors.flatMap((selector) => {
-    const es = Array.from(target.querySelectorAll(selector));
-    for (const e of es) {
-      e.addEventListener("keydown", stopPropagation);
-      e.addEventListener("keyup", stopPropagation);
-      e.addEventListener("keypress", stopPropagation);
-    }
-    return es;
-  });
-
-  return () => {
-    elementsStoppingPropagation?.forEach((e) => {
-      e.removeEventListener("keydown", stopPropagation);
-      e.removeEventListener("keyup", stopPropagation);
-      e.removeEventListener("keypress", stopPropagation);
+    const target = element === window ? document : (element as HTMLElement);
+    const elementsStoppingPropagation = selectors.flatMap((selector) => {
+      const es = Array.from(target.querySelectorAll(selector));
+      for (const e of es) {
+        e.addEventListener("keydown", stopPropagation);
+        e.addEventListener("keyup", stopPropagation);
+        e.addEventListener("keypress", stopPropagation);
+      }
+      return es;
     });
-  };
+
+    return () => {
+      elementsStoppingPropagation?.forEach((e) => {
+        e.removeEventListener("keydown", stopPropagation);
+        e.removeEventListener("keyup", stopPropagation);
+        e.removeEventListener("keypress", stopPropagation);
+      });
+    };
+  }, [element, selectors]);
 }
 
 export function useSyncedKeyboardEvents(

--- a/packages/keyboard-shortcuts/src/envelope/DefaultKeyboardShortcutsService.ts
+++ b/packages/keyboard-shortcuts/src/envelope/DefaultKeyboardShortcutsService.ts
@@ -80,7 +80,7 @@ const KEY_CODES = new Map<string, string>([
   ["z", "KeyZ"],
 ]);
 
-const IGNORED_TAGS = ["INPUT", "TEXTAREA", "SELECT", "OPTION", "TD"];
+const IGNORED_TAGS = ["INPUT", "TEXTAREA", "SELECT", "OPTION"];
 
 export class DefaultKeyboardShortcutsService {
   private eventIdentifiers = 1;

--- a/packages/stunner-editors-dmn-loader/src/index.tsx
+++ b/packages/stunner-editors-dmn-loader/src/index.tsx
@@ -32,8 +32,9 @@ import {
 } from "@kie-tools/boxed-expression-component";
 import { ImportJavaClasses, ImportJavaClassGWTService, JavaClass } from "@kie-tools/import-java-classes-component";
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import * as ReactDOM from "react-dom";
+import { useElementsThatStopKeyboardEventsPropagation } from "@kie-tools-core/keyboard-shortcuts/dist/channel";
 
 export interface BoxedExpressionEditorWrapperProps {
   /** Identifier of the decision node, where the expression will be hold */
@@ -115,6 +116,11 @@ const BoxedExpressionWrapper: React.FunctionComponent<BoxedExpressionEditorWrapp
       window.beeApiWrapper?.broadcastDecisionTableExpressionDefinition?.(definition);
     },
   };
+
+  useElementsThatStopKeyboardEventsPropagation(
+    window,
+    useMemo(() => [".boxed-expression-provider"], [])
+  );
 
   return (
     <BoxedExpressionEditor


### PR DESCRIPTION
I've extracted the `renderCell` to a new component, so we could use the `useRef` hook, and manually add the `keydown` listener. Also, I've fixed the `keyboard-shortcuts` hook, and I've added it to the `stunner-editors-dmn-loader` to block any key event to affect the Editor. As I said in your [PR](https://github.com/kiegroup/kie-tools/pull/825), this is just a possible solution, feel free to change it.