### PR TITLE
KOGITO-9956: Migrate custom dashboards from kogito-apps to kie-tools

### DIFF
--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListApi.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CustomDashboardListApi {}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListChannelApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListChannelApi.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CustomDashboardFilter, CustomDashboardInfo } from "./CustomDashboardListEnvelopeApi";
+/**
+ * Channel Api for CustomDashboard List
+ */
+export interface CustomDashboardListChannelApi {
+  customDashboardList__getFilter(): Promise<CustomDashboardFilter>;
+  customDashboardList__applyFilter(customDashboardFilter: CustomDashboardFilter): Promise<void>;
+  customDashboardList__getCustomDashboardQuery(): Promise<CustomDashboardInfo[]>;
+  customDashboardList__openDashboard(customDashboardInfo: CustomDashboardInfo): Promise<void>;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListDriver.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListDriver.ts
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CustomDashboardFilter, CustomDashboardInfo } from "./CustomDashboardListEnvelopeApi";
+
+/**
+ * Interface that defines a Driver for CustomDashboardList views.
+ */
+export interface CustomDashboardListDriver {
+  getCustomDashboardFilter(): Promise<CustomDashboardFilter>;
+  applyFilter(customDashboardFilter: CustomDashboardFilter): Promise<void>;
+  getCustomDashboardsQuery(): Promise<CustomDashboardInfo[]>;
+  openDashboard(customDashboardInfo: CustomDashboardInfo): Promise<void>;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListEnvelopeApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/api/CustomDashboardListEnvelopeApi.ts
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Envelope Api
+ */
+export interface CustomDashboardListEnvelopeApi {
+  /**
+   * Initializes the envelope.
+   * @param association
+   */
+  customDashboardList__init(association: Association): Promise<void>;
+}
+
+export interface Association {
+  origin: string;
+  envelopeServerId: string;
+}
+
+export interface CustomDashboardFilter {
+  customDashboardNames: string[];
+}
+
+export interface CustomDashboardInfo {
+  name: string;
+  path: string;
+  lastModified: Date;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/api/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/api/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./CustomDashboardListApi";
+export * from "./CustomDashboardListChannelApi";
+export * from "./CustomDashboardListEnvelopeApi";
+export * from "./CustomDashboardListDriver";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/embedded/CustomDashboardListChannelApiImpl.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/embedded/CustomDashboardListChannelApiImpl.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  CustomDashboardListDriver,
+  CustomDashboardListChannelApi,
+  CustomDashboardFilter,
+  CustomDashboardInfo,
+} from "../api";
+
+/**
+ * Implementation of the CustomDashboardListChannelApiImpl delegating to a CustomDashboardListDriver
+ */
+export class CustomDashboardListChannelApiImpl implements CustomDashboardListChannelApi {
+  constructor(private readonly driver: CustomDashboardListDriver) {}
+
+  customDashboardList__getFilter(): Promise<CustomDashboardFilter> {
+    return this.driver.getCustomDashboardFilter();
+  }
+
+  customDashboardList__applyFilter(customDashboardFilter: CustomDashboardFilter): Promise<void> {
+    return this.driver.applyFilter(customDashboardFilter);
+  }
+
+  customDashboardList__getCustomDashboardQuery(): Promise<CustomDashboardInfo[]> {
+    return this.driver.getCustomDashboardsQuery();
+  }
+
+  customDashboardList__openDashboard(customDashboardInfo: CustomDashboardInfo): Promise<void> {
+    return this.driver.openDashboard(customDashboardInfo);
+  }
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/embedded/EmbeddedCustomDashboardList.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/embedded/EmbeddedCustomDashboardList.tsx
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useCallback } from "react";
+import { EnvelopeServer } from "@kie-tools-core/envelope-bus/dist/channel";
+import { EmbeddedEnvelopeProps, RefForwardingEmbeddedEnvelope } from "@kie-tools-core/envelope/dist/embedded";
+import {
+  CustomDashboardListApi,
+  CustomDashboardListChannelApi,
+  CustomDashboardListEnvelopeApi,
+  CustomDashboardListDriver,
+} from "../api";
+import { CustomDashboardListChannelApiImpl } from "./CustomDashboardListChannelApiImpl";
+import { ContainerType } from "@kie-tools-core/envelope/dist/api";
+import { init } from "../envelope";
+
+export interface Props {
+  targetOrigin: string;
+  driver: CustomDashboardListDriver;
+}
+
+export const EmbeddedCustomDashboardList = React.forwardRef(
+  (props: Props, forwardedRef: React.Ref<CustomDashboardListApi>) => {
+    const refDelegate = useCallback(
+      (
+        envelopeServer: EnvelopeServer<CustomDashboardListChannelApi, CustomDashboardListEnvelopeApi>
+      ): CustomDashboardListApi => ({}),
+      []
+    );
+    const pollInit = useCallback(
+      (
+        envelopeServer: EnvelopeServer<CustomDashboardListChannelApi, CustomDashboardListEnvelopeApi>,
+        container: () => HTMLDivElement
+      ) => {
+        init({
+          config: {
+            containerType: ContainerType.DIV,
+            envelopeId: envelopeServer.id,
+          },
+          container: container(),
+          bus: {
+            postMessage(message, targetOrigin, transfer) {
+              window.postMessage(message, targetOrigin!, transfer);
+            },
+          },
+        });
+        return envelopeServer.envelopeApi.requests.customDashboardList__init({
+          origin: envelopeServer.origin,
+          envelopeServerId: envelopeServer.id,
+        });
+      },
+      []
+    );
+
+    return (
+      <EmbeddedCustomDashboardListEnvelope
+        ref={forwardedRef}
+        apiImpl={new CustomDashboardListChannelApiImpl(props.driver)}
+        origin={props.targetOrigin}
+        refDelegate={refDelegate}
+        pollInit={pollInit}
+        config={{ containerType: ContainerType.DIV }}
+      />
+    );
+  }
+);
+
+const EmbeddedCustomDashboardListEnvelope = React.forwardRef<
+  CustomDashboardListApi,
+  EmbeddedEnvelopeProps<CustomDashboardListChannelApi, CustomDashboardListEnvelopeApi, CustomDashboardListApi>
+>(RefForwardingEmbeddedEnvelope);

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/embedded/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/embedded/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./EmbeddedCustomDashboardList";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelope.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelope.tsx
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { EnvelopeBus } from "@kie-tools-core/envelope-bus/dist/api";
+import { CustomDashboardListChannelApi, CustomDashboardListEnvelopeApi } from "../api";
+import { CustomDashboardListEnvelopeContext } from "./CustomDashboardListEnvelopeContext";
+import { CustomDashboardListEnvelopeView, CustomDashboardListEnvelopeViewApi } from "./CustomDashboardListEnvelopeView";
+import { CustomDashboardListEnvelopeApiImpl } from "./CustomDashboardListEnvelopeApiImpl";
+import { Envelope, EnvelopeDivConfig } from "@kie-tools-core/envelope";
+
+/**
+ * Function that starts an Envelope application.
+ *
+ * @param args.container: The HTML element in which the CustomDashboardList will render
+ * @param args.bus: The implementation of a `bus` that knows how to send messages to the Channel.
+ *
+ */
+export function init(args: { config: EnvelopeDivConfig; container: HTMLDivElement; bus: EnvelopeBus }) {
+  /**
+   * Creates a new generic Envelope, typed with the right interfaces.
+   */
+  const envelope = new Envelope<
+    CustomDashboardListEnvelopeApi,
+    CustomDashboardListChannelApi,
+    CustomDashboardListEnvelopeViewApi,
+    CustomDashboardListEnvelopeContext
+  >(args.bus, args.config);
+
+  /**
+   * Function that knows how to render a CustomDashboardList.
+   * In this case, it's a React application, but any other framework can be used.
+   *
+   * Returns a Promise<() => CustomDashboardListEnvelopeViewApi> that can be used in CustomDashboardListEnvelopeApiImpl.
+   */
+  const envelopeViewDelegate = async () => {
+    const ref = React.createRef<CustomDashboardListEnvelopeViewApi>();
+    return new Promise<() => CustomDashboardListEnvelopeViewApi>((res) => {
+      ReactDOM.render(
+        <CustomDashboardListEnvelopeView ref={ref} channelApi={envelope.channelApi} />,
+        args.container,
+        () => res(() => ref.current!)
+      );
+    });
+  };
+
+  const context: CustomDashboardListEnvelopeContext = {};
+  return envelope.start(envelopeViewDelegate, context, {
+    create: (apiFactoryArgs) => new CustomDashboardListEnvelopeApiImpl(apiFactoryArgs),
+  });
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeApiImpl.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeApiImpl.ts
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
+import { CustomDashboardListEnvelopeViewApi } from "./CustomDashboardListEnvelopeView";
+import { Association, CustomDashboardListChannelApi, CustomDashboardListEnvelopeApi } from "../api";
+import { CustomDashboardListEnvelopeContext } from "./CustomDashboardListEnvelopeContext";
+
+/**
+ * Implementation of the CustomDashboardListEnvelopeApi
+ */
+export class CustomDashboardListEnvelopeApiImpl implements CustomDashboardListEnvelopeApi {
+  private view: () => CustomDashboardListEnvelopeViewApi;
+  private capturedInitRequestYet = false;
+  constructor(
+    private readonly args: EnvelopeApiFactoryArgs<
+      CustomDashboardListEnvelopeApi,
+      CustomDashboardListChannelApi,
+      CustomDashboardListEnvelopeViewApi,
+      CustomDashboardListEnvelopeContext
+    >
+  ) {}
+
+  private hasCapturedInitRequestYet() {
+    return this.capturedInitRequestYet;
+  }
+
+  private ackCapturedInitRequest() {
+    this.capturedInitRequestYet = true;
+  }
+
+  customDashboardList__init = async (association: Association): Promise<void> => {
+    this.args.envelopeClient.associate(association.origin, association.envelopeServerId);
+
+    if (this.hasCapturedInitRequestYet()) {
+      return;
+    }
+
+    this.ackCapturedInitRequest();
+    this.view = await this.args.viewDelegate();
+    this.view().initialize();
+  };
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeContext.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeContext.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This is a convenience class that the Envelope view can use.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface CustomDashboardListEnvelopeContext {}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeView.tsx
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useImperativeHandle, useState } from "react";
+import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import { CustomDashboardListChannelApi } from "../api";
+import CustomDashboardList from "./components/CustomDashboardList/CustomDashboardList";
+import CustomDashboardListEnvelopeViewDriver from "./CustomDashboardListEnvelopeViewDriver";
+import "@patternfly/patternfly/patternfly.css";
+
+export interface CustomDashboardListEnvelopeViewApi {
+  initialize: () => void;
+}
+
+interface Props {
+  channelApi: MessageBusClientApi<CustomDashboardListChannelApi>;
+}
+
+export const CustomDashboardListEnvelopeView = React.forwardRef<CustomDashboardListEnvelopeViewApi, Props>(
+  (props, forwardedRef) => {
+    const [isEnvelopeConnectedToChannel, setEnvelopeConnectedToChannel] = useState<boolean>(false);
+    useImperativeHandle(
+      forwardedRef,
+      () => ({
+        initialize: () => {
+          setEnvelopeConnectedToChannel(true);
+        },
+      }),
+      []
+    );
+
+    return (
+      <React.Fragment>
+        <CustomDashboardList
+          isEnvelopeConnectedToChannel={isEnvelopeConnectedToChannel}
+          driver={new CustomDashboardListEnvelopeViewDriver(props.channelApi)}
+        />
+      </React.Fragment>
+    );
+  }
+);
+
+export default CustomDashboardListEnvelopeView;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeViewDriver.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/CustomDashboardListEnvelopeViewDriver.ts
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import {
+  CustomDashboardFilter,
+  CustomDashboardListChannelApi,
+  CustomDashboardListDriver,
+  CustomDashboardInfo,
+} from "../api";
+
+/**
+ * Implementation of CustomDashboardListDriver that delegates calls to the channel Api
+ */
+export default class CustomDashboardListEnvelopeViewDriver implements CustomDashboardListDriver {
+  constructor(private readonly channelApi: MessageBusClientApi<CustomDashboardListChannelApi>) {}
+
+  getCustomDashboardFilter(): Promise<CustomDashboardFilter> {
+    return this.channelApi.requests.customDashboardList__getFilter();
+  }
+
+  applyFilter(customDashboardFilter: CustomDashboardFilter): Promise<void> {
+    return this.channelApi.requests.customDashboardList__applyFilter(customDashboardFilter);
+  }
+
+  getCustomDashboardsQuery(): Promise<CustomDashboardInfo[]> {
+    return this.channelApi.requests.customDashboardList__getCustomDashboardQuery();
+  }
+
+  openDashboard(customDashboardInfo: CustomDashboardInfo): Promise<void> {
+    return this.channelApi.requests.customDashboardList__openDashboard(customDashboardInfo);
+  }
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardCard/CustomDashboardCard.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardCard/CustomDashboardCard.tsx
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { OUIAProps, componentOuiaProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
+import { TextVariants, Text } from "@patternfly/react-core/dist/js/components/Text";
+import { Card, CardBody, CardHeaderMain, CardHeader } from "@patternfly/react-core/dist/js/components/Card";
+import { FormGroup, Form } from "@patternfly/react-core/dist/js/components/Form";
+import { CustomDashboardInfo } from "../../../api/CustomDashboardListEnvelopeApi";
+import { CustomDashboardListDriver } from "../../../api/CustomDashboardListDriver";
+import Moment from "react-moment";
+export interface CustomDashboardCardProps {
+  customDashboardData: CustomDashboardInfo;
+  driver: CustomDashboardListDriver;
+}
+
+const CustomDashboardCard: React.FC<CustomDashboardCardProps & OUIAProps> = ({
+  customDashboardData,
+  driver,
+  ouiaId,
+  ouiaSafe,
+}) => {
+  const handleCardClick = (): void => {
+    driver.openDashboard(customDashboardData);
+  };
+
+  return (
+    <Card
+      {...componentOuiaProps(ouiaId, "customDashboard-card", ouiaSafe)}
+      isSelectable
+      onClick={handleCardClick}
+      data-testid="card"
+    >
+      <CardHeader>
+        <CardHeaderMain>Empty</CardHeaderMain>
+      </CardHeader>
+      <CardHeader>
+        <Text component={TextVariants.h1} className="pf-u-font-weight-bold">
+          {customDashboardData.name}
+        </Text>
+      </CardHeader>
+      <CardBody>
+        <div className="pf-u-mt-md">
+          <Form>
+            <FormGroup label="Path" fieldId="path">
+              <Text component={TextVariants.p}>{customDashboardData.path}</Text>
+            </FormGroup>
+            <FormGroup label="LastModified" fieldId="lastModified">
+              <Text component={TextVariants.p}>
+                <Moment fromNow>{customDashboardData.lastModified}</Moment>
+              </Text>
+            </FormGroup>
+          </Form>
+        </div>
+      </CardBody>
+    </Card>
+  );
+};
+
+export default CustomDashboardCard;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardList/CustomDashboardList.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardList/CustomDashboardList.tsx
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { OUIAProps, componentOuiaProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
+import { CustomDashboardListDriver } from "../../../api/CustomDashboardListDriver";
+import CustomDashboardListToolbar from "../CustomDashboardListToolbar/CustomDashboardListToolbar";
+import { Divider } from "@patternfly/react-core/dist/js/components/Divider";
+import { ToggleGroup, ToggleGroupItem } from "@patternfly/react-core/dist/js/components/ToggleGroup";
+import { Split, SplitItem } from "@patternfly/react-core/dist/js/layouts/Split";
+import { CustomDashboardInfo, CustomDashboardFilter } from "../../../api/CustomDashboardListEnvelopeApi";
+import CustomDashboardsTable from "../CustomDashboardsTable/CustomDashboardsTable";
+import CustomDashboardsGallery from "../CustomDashboardsGallery/CustomDashboardsGallery";
+import { BarsIcon } from "@patternfly/react-icons/dist/js/icons/bars-icon";
+import { ThIcon } from "@patternfly/react-icons/dist/js/icons/th-icon";
+import { ServerErrors } from "@kie-tools/runtime-tools-components/dist/components/ServerErrors";
+export interface CustomDashboardListProps {
+  isEnvelopeConnectedToChannel: boolean;
+  driver: CustomDashboardListDriver;
+}
+
+const CustomDashboardList: React.FC<CustomDashboardListProps & OUIAProps> = ({
+  isEnvelopeConnectedToChannel,
+  driver,
+  ouiaId,
+  ouiaSafe,
+}) => {
+  const [filterNames, setFilterNames] = useState<string[]>([]);
+  const [dashboardData, setDashboardData] = useState<CustomDashboardInfo[]>([]);
+  const [isSelected] = useState<{
+    tableView: boolean;
+    cardsView: boolean;
+  }>({
+    tableView: true,
+    cardsView: false,
+  });
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<any>(null);
+
+  useEffect(() => {
+    if (!isEnvelopeConnectedToChannel) {
+      setIsLoading(true);
+      return;
+    }
+    init();
+  }, [isEnvelopeConnectedToChannel]);
+
+  const init = async (): Promise<void> => {
+    try {
+      const namesFilter = await driver.getCustomDashboardFilter();
+      setFilterNames(namesFilter.customDashboardNames);
+      setIsLoading(true);
+      const response = await driver.getCustomDashboardsQuery();
+      setDashboardData(response);
+      setIsLoading(false);
+    } catch (errorResponse) {
+      setError(errorResponse);
+    }
+  };
+
+  const applyFilter = (filters: CustomDashboardFilter): void => {
+    driver.applyFilter(filters);
+    init();
+  };
+
+  /* Re-enable card view after thumbnails are available */
+  /*const handleItemClick = (isChosen, event): void => {
+    const toggleButtonId = event.currentTarget.id;
+    if (toggleButtonId === 'tableView') {
+      setIsSelected({
+        tableView: true,
+        cardsView: false
+      });
+    } else if (toggleButtonId === 'cardsView') {
+      setIsSelected({
+        tableView: false,
+        cardsView: true
+      });
+    }
+  };*/
+
+  if (error) {
+    return <ServerErrors error={error.message} variant={"large"} />;
+  }
+
+  return (
+    <div {...componentOuiaProps(ouiaId, "custom-dashboard-list", ouiaSafe)}>
+      <Split hasGutter>
+        <SplitItem>
+          <CustomDashboardListToolbar
+            applyFilter={applyFilter}
+            setFilterDashboardNames={setFilterNames}
+            filterDashboardNames={filterNames}
+          />
+        </SplitItem>
+        <SplitItem isFilled></SplitItem>
+
+        {/* Re-enable card view after thumbnails are available */
+        /*<SplitItem style={{ padding: '20px' }}>
+          <ToggleGroup aria-label="switch view toggle group">
+            <ToggleGroupItem
+              icon={<BarsIcon />}
+              aria-label="table view icon button"
+              buttonId="tableView"
+              isSelected={isSelected.tableView}
+              onChange={handleItemClick}
+            />
+            <ToggleGroupItem
+              icon={<ThIcon />}
+              aria-label="card view icon button"
+              buttonId="cardsView"
+              isSelected={isSelected.cardsView}
+              onChange={handleItemClick}
+            />
+          </ToggleGroup>
+        </SplitItem>
+        */}
+      </Split>
+      <Divider />
+      {isSelected.tableView ? (
+        <CustomDashboardsTable
+          driver={driver}
+          customDashboardData={dashboardData}
+          setDashboardsData={setDashboardData}
+          isLoading={isLoading}
+        />
+      ) : (
+        <CustomDashboardsGallery customDashboardsDatas={dashboardData} driver={driver} isLoading={isLoading} />
+      )}
+    </div>
+  );
+};
+
+export default CustomDashboardList;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardListToolbar/CustomDashboardListToolbar.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardListToolbar/CustomDashboardListToolbar.tsx
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState } from "react";
+import {
+  ToolbarFilter,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarToggleGroup,
+  Toolbar,
+  ToolbarContent,
+} from "@patternfly/react-core/dist/js/components/Toolbar";
+import { Button } from "@patternfly/react-core/dist/js/components/Button";
+import { Tooltip } from "@patternfly/react-core/dist/js/components/Tooltip";
+import { TextInput } from "@patternfly/react-core/dist/js/components/TextInput";
+import { InputGroup } from "@patternfly/react-core/dist/js/components/InputGroup";
+import { FilterIcon } from "@patternfly/react-icons/dist/js/icons/filter-icon";
+import { SyncIcon } from "@patternfly/react-icons/dist/js/icons/sync-icon";
+import _ from "lodash";
+import { componentOuiaProps, OUIAProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
+import { CustomDashboardFilter } from "../../../api";
+
+interface CustomDashboardListToolbarProps {
+  filterDashboardNames: string[];
+  setFilterDashboardNames: React.Dispatch<React.SetStateAction<string[]>>;
+  applyFilter: (filter: CustomDashboardFilter) => void;
+}
+
+enum Category {
+  CUSTOM_DASHBOARD_NAME = "Custom Dashboard name",
+}
+
+const CustomDashboardListToolbar: React.FC<CustomDashboardListToolbarProps & OUIAProps> = ({
+  applyFilter,
+  filterDashboardNames,
+  setFilterDashboardNames,
+  ouiaSafe,
+  ouiaId,
+}) => {
+  const [dashboardNameInput, setDashboardNameInput] = useState<string>("");
+
+  const doResetFilter = (): void => {
+    applyFilter({
+      customDashboardNames: [],
+    });
+    setFilterDashboardNames([]);
+  };
+
+  const doRefresh = (): void => {
+    applyFilter({
+      customDashboardNames: [...filterDashboardNames],
+    });
+  };
+
+  const onEnterClicked = (event: React.KeyboardEvent<EventTarget>): void => {
+    /* istanbul ignore else */
+    if (event.key === "Enter") {
+      dashboardNameInput.length > 0 && doApplyFilter();
+    }
+  };
+
+  const onDeleteFilterGroup = (categoryName: Category, value: string): void => {
+    const newFilterDashboardNames = [...filterDashboardNames];
+    if (categoryName === Category.CUSTOM_DASHBOARD_NAME) {
+      _.remove(newFilterDashboardNames, (status: string) => {
+        return status === value;
+      });
+      setFilterDashboardNames(newFilterDashboardNames);
+      applyFilter({
+        customDashboardNames: newFilterDashboardNames,
+      });
+    }
+  };
+
+  const doApplyFilter = (): void => {
+    const newDashboardNames = [...filterDashboardNames];
+    if (dashboardNameInput && !newDashboardNames.includes(dashboardNameInput)) {
+      newDashboardNames.push(dashboardNameInput);
+      setFilterDashboardNames(newDashboardNames);
+    }
+    setDashboardNameInput("");
+    applyFilter({
+      customDashboardNames: newDashboardNames,
+    });
+  };
+
+  const toggleGroupItems: JSX.Element = (
+    <React.Fragment>
+      <ToolbarGroup variant="filter-group">
+        <ToolbarFilter
+          key="input-customDashboard-name"
+          chips={filterDashboardNames}
+          deleteChip={onDeleteFilterGroup}
+          categoryName={Category.CUSTOM_DASHBOARD_NAME}
+        >
+          <InputGroup>
+            <TextInput
+              name="customDashboardName"
+              id="customDashboardName"
+              type="search"
+              aria-label="Dashboard name"
+              onChange={setDashboardNameInput}
+              onKeyPress={onEnterClicked}
+              placeholder="Filter by dashboard name"
+              value={dashboardNameInput}
+              data-testid="search-input"
+            />
+          </InputGroup>
+        </ToolbarFilter>
+        <ToolbarItem>
+          <Button id="apply-filter" variant="primary" onClick={doApplyFilter} data-testid="apply-filter">
+            Apply Filter
+          </Button>
+        </ToolbarItem>
+      </ToolbarGroup>
+    </React.Fragment>
+  );
+
+  const toolbarItems: JSX.Element = (
+    <React.Fragment>
+      <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="xl">
+        {toggleGroupItems}
+      </ToolbarToggleGroup>
+      <ToolbarGroup variant="icon-button-group">
+        <ToolbarItem>
+          <Tooltip content={"Refresh"}>
+            <Button variant="plain" onClick={doRefresh} id="refresh" data-testid="refresh">
+              <SyncIcon />
+            </Button>
+          </Tooltip>
+        </ToolbarItem>
+      </ToolbarGroup>
+    </React.Fragment>
+  );
+
+  return (
+    <Toolbar
+      id="custom-dashboard-list-with-filter"
+      className="pf-m-toggle-group-container"
+      collapseListedFiltersBreakpoint="xl"
+      clearAllFilters={doResetFilter}
+      clearFiltersButtonText="Reset to default"
+      {...componentOuiaProps(ouiaId, "custom-dashboard-list-toolbar", ouiaSafe)}
+    >
+      <ToolbarContent>{toolbarItems}</ToolbarContent>
+    </Toolbar>
+  );
+};
+
+export default CustomDashboardListToolbar;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardListUtils/CustomDashboardListUtils.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardListUtils/CustomDashboardListUtils.tsx
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import Moment from "react-moment";
+import { DataTableColumn } from "@kie-tools/runtime-tools-components/dist/components/DataTable";
+import { CustomDashboardInfo } from "../../../api/CustomDashboardListEnvelopeApi";
+
+export const getDashboardNameColumn = (
+  selectDashboard: (customDashboardInfo: CustomDashboardInfo) => void
+): DataTableColumn => {
+  return {
+    label: "Name",
+    path: "name",
+    bodyCellTransformer: (cellValue, rowDashboard: CustomDashboardInfo) => {
+      return (
+        <a onClick={() => selectDashboard(rowDashboard)}>
+          <strong>{cellValue}</strong>
+        </a>
+      );
+    },
+    isSortable: true,
+  };
+};
+
+export const getDateColumn = (columnPath: string, columnLabel: string): DataTableColumn => {
+  return {
+    label: columnLabel,
+    path: columnPath,
+    bodyCellTransformer: (value) => <Moment fromNow>{new Date(`${value}`)}</Moment>,
+    isSortable: true,
+  };
+};

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardsGallery/CustomDashboardsGallery.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardsGallery/CustomDashboardsGallery.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from "react";
+import { OUIAProps, componentOuiaProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
+import { Gallery, GalleryItem } from "@patternfly/react-core/dist/js/layouts/Gallery";
+import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
+import { CustomDashboardInfo } from "../../../api/CustomDashboardListEnvelopeApi";
+import CustomDashboardCard from "../CustomDashboardCard/CustomDashboardCard";
+import { CustomDashboardListDriver } from "../../../api/CustomDashboardListDriver";
+import { KogitoSpinner } from "@kie-tools/runtime-tools-components/dist/components/KogitoSpinner";
+import {
+  KogitoEmptyState,
+  KogitoEmptyStateType,
+} from "@kie-tools/runtime-tools-components/dist/components/KogitoEmptyState";
+
+export interface CustomDashboardGalleryProps {
+  driver: CustomDashboardListDriver;
+  customDashboardsDatas: CustomDashboardInfo[];
+  isLoading: boolean;
+}
+
+const CustomDashboardsGallery: React.FC<CustomDashboardGalleryProps & OUIAProps> = ({
+  driver,
+  customDashboardsDatas,
+  isLoading,
+  ouiaId,
+  ouiaSafe,
+}) => {
+  if (isLoading) {
+    return (
+      <Bullseye>
+        <KogitoSpinner
+          spinnerText="Loading customDashboard..."
+          ouiaId="custom-dashboard-list-loading-custom-dashboard"
+        />
+      </Bullseye>
+    );
+  }
+
+  if (!isLoading && customDashboardsDatas && customDashboardsDatas.length === 0) {
+    return (
+      <KogitoEmptyState
+        type={KogitoEmptyStateType.Search}
+        title="No results found"
+        body="Try using different filters"
+      />
+    );
+  }
+
+  return (
+    <Gallery hasGutter style={{ margin: "25px" }} {...componentOuiaProps(ouiaId, "customDashboard-gallery", ouiaSafe)}>
+      {customDashboardsDatas &&
+        customDashboardsDatas.map((customDashboardData, index) => (
+          <GalleryItem key={index}>
+            <CustomDashboardCard
+              customDashboardData={customDashboardData}
+              key={index}
+              driver={driver}
+            ></CustomDashboardCard>
+          </GalleryItem>
+        ))}
+    </Gallery>
+  );
+};
+
+export default CustomDashboardsGallery;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardsTable/CustomDashboardsTable.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/components/CustomDashboardsTable/CustomDashboardsTable.tsx
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from "react";
+import { DataTable, DataTableColumn } from "@kie-tools/runtime-tools-components/dist/components/DataTable";
+import { KogitoSpinner } from "@kie-tools/runtime-tools-components/dist/components/KogitoSpinner";
+import { OUIAProps, componentOuiaProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
+import { CustomDashboardInfo, CustomDashboardListDriver } from "../../../api";
+import { getDashboardNameColumn, getDateColumn } from "../CustomDashboardListUtils/CustomDashboardListUtils";
+import _ from "lodash";
+import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
+import { ISortBy } from "@patternfly/react-table/dist/js/components/Table";
+
+export interface CustomDashboardTableProps {
+  driver: CustomDashboardListDriver;
+  customDashboardData: CustomDashboardInfo[];
+  setDashboardsData: React.Dispatch<React.SetStateAction<CustomDashboardInfo[]>>;
+  isLoading: boolean;
+}
+interface SortBy {
+  property: string;
+  direction: "asc" | "desc";
+}
+
+const CustomDashboardsTable: React.FC<CustomDashboardTableProps & OUIAProps> = ({
+  driver,
+  customDashboardData,
+  setDashboardsData,
+  isLoading,
+  ouiaId,
+  ouiaSafe,
+}) => {
+  const [columns] = useState<DataTableColumn[]>([
+    getDashboardNameColumn(
+      (customDashboardInfo: CustomDashboardInfo): Promise<void> => driver.openDashboard(customDashboardInfo)
+    ),
+    getDateColumn("lastModified", "Last Modified"),
+  ]);
+  const [sortBy, setSortBy] = useState<SortBy>({
+    property: "lastModified",
+    direction: "desc",
+  });
+
+  useEffect(() => {
+    /* istanbul ignore else */
+    if (!_.isEmpty(customDashboardData)) {
+      onSort(2, "desc");
+    }
+  }, [isLoading]);
+
+  const getSortBy = (): ISortBy => {
+    return {
+      index: columns.findIndex((column) => column.path === sortBy.property),
+      direction: sortBy.direction,
+    };
+  };
+
+  const onSort = async (index: number, direction: "asc" | "desc"): Promise<void> => {
+    const sortObj: SortBy = {
+      property: columns[index - 1].path,
+      direction: direction,
+    };
+
+    const sortedData = _.orderBy(
+      customDashboardData,
+      _.keys({
+        [sortObj.property]: sortObj.direction,
+      }),
+      _.values({
+        [sortObj.property]: sortObj.direction,
+      })
+    );
+    setDashboardsData(sortedData);
+    setSortBy(sortObj);
+  };
+
+  const customDashboardLoadingComponent: JSX.Element = (
+    <Bullseye>
+      <KogitoSpinner spinnerText="Loading Dashboard..." ouiaId="custom-dashboard-list-custom-dashboard-list" />
+    </Bullseye>
+  );
+
+  return (
+    <div {...componentOuiaProps(ouiaId, "customDashboard-table", ouiaSafe)}>
+      <DataTable
+        data={customDashboardData}
+        isLoading={isLoading}
+        columns={columns}
+        error={false}
+        sortBy={getSortBy()}
+        onSorting={onSort}
+        LoadingComponent={customDashboardLoadingComponent}
+      />
+    </div>
+  );
+};
+
+export default CustomDashboardsTable;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/envelope/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./CustomDashboardListEnvelope";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardList/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardList/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./api";
+export * from "./embedded";
+export * from "./envelope";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewApi.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface CustomDashboardViewApi {
+  // custom dashboard view api
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewApi.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CustomDashboardViewApi {
   // custom dashboard view api
 }

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewChannelApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewChannelApi.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface CustomDashboardViewChannelApi {
+  customDashboardView__getCustomDashboardView(name: string): Promise<string>;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewDriver.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewDriver.ts
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Interface that defines a Driver for CustomDashboard views.
+ */
+export interface CustomDashboardViewDriver {
+  getCustomDashboardContent(name: string): Promise<string>;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewEnvelopeApi.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/api/CustomDashboardViewEnvelopeApi.ts
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Envelope Api
+ */
+export interface CustomDashboardViewEnvelopeApi {
+  /**
+   * Initializes the envelope.
+   * @param association
+   */
+  customDashboardView__init(association: Association, dashboardName: string): Promise<void>;
+}
+
+export interface Association {
+  origin: string;
+  envelopeServerId: string;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/api/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/api/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./CustomDashboardViewApi";
+export * from "./CustomDashboardViewChannelApi";
+export * from "./CustomDashboardViewEnvelopeApi";
+export * from "./CustomDashboardViewDriver";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/dashbuilder/setup.js
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/dashbuilder/setup.js
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+dashbuilder = {
+  mode: "EDITOR",
+};

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/CustomDashboardViewChannelApiImpl.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/CustomDashboardViewChannelApiImpl.ts
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CustomDashboardViewChannelApi, CustomDashboardViewDriver } from "../api";
+
+/**
+ * Implementation of the CustomDashboardViewChannelApiImpl delegating to a CustomDashboardViewDriver
+ */
+export class CustomDashboardViewChannelApiImpl implements CustomDashboardViewChannelApi {
+  constructor(private readonly driver: CustomDashboardViewDriver) {}
+
+  customDashboardView__getCustomDashboardView(name: string): Promise<string> {
+    return this.driver.getCustomDashboardContent(name);
+  }
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/EmbeddedCustomDashboardView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/EmbeddedCustomDashboardView.tsx
@@ -56,7 +56,7 @@ export const EmbeddedCustomDashboardView = React.forwardRef(
           container: container(),
           bus: {
             postMessage(message, targetOrigin, transfer) {
-              window.postMessage(message, targetOrigin, transfer);
+              window.postMessage(message, targetOrigin!, transfer);
             },
           },
         });

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/EmbeddedCustomDashboardView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/EmbeddedCustomDashboardView.tsx
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, { useCallback } from "react";
+import { EnvelopeServer } from "@kie-tools-core/envelope-bus/dist/channel";
+import { EmbeddedEnvelopeProps, RefForwardingEmbeddedEnvelope } from "@kie-tools-core/envelope/dist/embedded";
+import {
+  CustomDashboardViewApi,
+  CustomDashboardViewChannelApi,
+  CustomDashboardViewEnvelopeApi,
+  CustomDashboardViewDriver,
+} from "../api";
+import { CustomDashboardViewChannelApiImpl } from "./CustomDashboardViewChannelApiImpl";
+import { ContainerType } from "@kie-tools-core/envelope/dist/api";
+import { init } from "../envelope";
+
+export interface Props {
+  targetOrigin: string;
+  driver: CustomDashboardViewDriver;
+  dashboardName: string;
+}
+
+export const EmbeddedCustomDashboardView = React.forwardRef(
+  (props: Props, forwardedRef: React.Ref<CustomDashboardViewApi>) => {
+    const refDelegate = useCallback(
+      (
+        envelopeServer: EnvelopeServer<CustomDashboardViewChannelApi, CustomDashboardViewEnvelopeApi>
+      ): CustomDashboardViewApi => ({}),
+      []
+    );
+    const pollInit = useCallback(
+      (
+        envelopeServer: EnvelopeServer<CustomDashboardViewChannelApi, CustomDashboardViewEnvelopeApi>,
+        container: () => HTMLDivElement
+      ) => {
+        init({
+          config: {
+            containerType: ContainerType.DIV,
+            envelopeId: envelopeServer.id,
+          },
+          container: container(),
+          bus: {
+            postMessage(message, targetOrigin, transfer) {
+              window.postMessage(message, targetOrigin, transfer);
+            },
+          },
+        });
+        return envelopeServer.envelopeApi.requests.customDashboardView__init(
+          {
+            origin: envelopeServer.origin,
+            envelopeServerId: envelopeServer.id,
+          },
+          props.dashboardName
+        );
+      },
+      []
+    );
+
+    return (
+      <EmbeddedCustomDashboardViewEnvelope
+        ref={forwardedRef}
+        apiImpl={new CustomDashboardViewChannelApiImpl(props.driver)}
+        origin={props.targetOrigin}
+        refDelegate={refDelegate}
+        pollInit={pollInit}
+        config={{ containerType: ContainerType.DIV }}
+      />
+    );
+  }
+);
+
+const EmbeddedCustomDashboardViewEnvelope = React.forwardRef<
+  CustomDashboardViewApi,
+  EmbeddedEnvelopeProps<CustomDashboardViewChannelApi, CustomDashboardViewEnvelopeApi, CustomDashboardViewApi>
+>(RefForwardingEmbeddedEnvelope);

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/embedded/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./EmbeddedCustomDashboardView";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelope.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelope.tsx
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { EnvelopeBus } from "@kie-tools-core/envelope-bus/dist/api";
+import { CustomDashboardViewChannelApi, CustomDashboardViewEnvelopeApi } from "../api";
+import { CustomDashboardViewEnvelopeContext } from "./CustomDashboardViewEnvelopeContext";
+import { CustomDashboardViewEnvelopeView, CustomDashboardViewEnvelopeViewApi } from "./CustomDashboardViewEnvelopeView";
+import { CustomDashboardViewEnvelopeApiImpl } from "./CustomDashboardViewEnvelopeApiImpl";
+import { Envelope, EnvelopeDivConfig } from "@kie-tools-core/envelope";
+
+/**
+ * Function that starts an Envelope application.
+ *
+ * @param args.container: The HTML element in which the CustomDashboardView will render
+ * @param args.bus: The implementation of a `bus` that knows how to send messages to the Channel.
+ *
+ */
+export function init(args: { config: EnvelopeDivConfig; container: HTMLDivElement; bus: EnvelopeBus }) {
+  /**
+   * Creates a new generic Envelope, typed with the right interfaces.
+   */
+  const envelope = new Envelope<
+    CustomDashboardViewEnvelopeApi,
+    CustomDashboardViewChannelApi,
+    CustomDashboardViewEnvelopeViewApi,
+    CustomDashboardViewEnvelopeContext
+  >(args.bus, args.config);
+
+  /**
+   * Function that knows how to render a CustomDashboardView.
+   * In this case, it's a React application, but any other framework can be used.
+   *
+   * Returns a Promise<() => CustomDashboardViewEnvelopeViewApi> that can be used in CustomDashboardViewEnvelopeApiImpl.
+   */
+  const envelopeViewDelegate = async () => {
+    const ref = React.createRef<CustomDashboardViewEnvelopeViewApi>();
+    return new Promise<() => CustomDashboardViewEnvelopeViewApi>((res) => {
+      ReactDOM.render(
+        <CustomDashboardViewEnvelopeView ref={ref} channelApi={envelope.channelApi} />,
+        args.container,
+        () => res(() => ref.current)
+      );
+    });
+  };
+
+  const context: CustomDashboardViewEnvelopeContext = {};
+  return envelope.start(envelopeViewDelegate, context, {
+    create: (apiFactoryArgs) => new CustomDashboardViewEnvelopeApiImpl(apiFactoryArgs),
+  });
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelope.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelope.tsx
@@ -56,7 +56,7 @@ export function init(args: { config: EnvelopeDivConfig; container: HTMLDivElemen
       ReactDOM.render(
         <CustomDashboardViewEnvelopeView ref={ref} channelApi={envelope.channelApi} />,
         args.container,
-        () => res(() => ref.current)
+        () => res(() => ref.current!)
       );
     });
   };

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeApiImpl.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeApiImpl.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { EnvelopeApiFactoryArgs } from "@kie-tools-core/envelope";
+import { CustomDashboardViewEnvelopeViewApi } from "./CustomDashboardViewEnvelopeView";
+import { Association, CustomDashboardViewChannelApi, CustomDashboardViewEnvelopeApi } from "../api";
+import { CustomDashboardViewEnvelopeContext } from "./CustomDashboardViewEnvelopeContext";
+
+/**
+ * Implementation of the CustomDashboardViewEnvelopeApi
+ */
+export class CustomDashboardViewEnvelopeApiImpl implements CustomDashboardViewEnvelopeApi {
+  private view: () => CustomDashboardViewEnvelopeViewApi;
+  private capturedInitRequestYet = false;
+  constructor(
+    private readonly args: EnvelopeApiFactoryArgs<
+      CustomDashboardViewEnvelopeApi,
+      CustomDashboardViewChannelApi,
+      CustomDashboardViewEnvelopeViewApi,
+      CustomDashboardViewEnvelopeContext
+    >
+  ) {}
+
+  private hasCapturedInitRequestYet() {
+    return this.capturedInitRequestYet;
+  }
+
+  private ackCapturedInitRequest() {
+    this.capturedInitRequestYet = true;
+  }
+
+  customDashboardView__init = async (association: Association, dashboardName: string): Promise<void> => {
+    this.args.envelopeClient?.associate(association.origin, association.envelopeServerId);
+
+    if (this.hasCapturedInitRequestYet()) {
+      return;
+    }
+    this.ackCapturedInitRequest();
+    this.view = await this.args.viewDelegate();
+    this.view().initialize(dashboardName, association.origin);
+  };
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeContext.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeContext.ts
@@ -20,4 +20,5 @@
 /**
  * This is a convenience class that the Envelope view can use.
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface CustomDashboardViewEnvelopeContext {}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeContext.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeContext.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This is a convenience class that the Envelope view can use.
+ */
+export interface CustomDashboardViewEnvelopeContext {}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeView.tsx
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useImperativeHandle, useState } from "react";
+import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import { CustomDashboardViewChannelApi } from "../api";
+import CustomDashboardView from "./components/CustomDashboardView/CustomDashboardView";
+import CustomDashboardViewEnvelopeViewDriver from "./CustomDashboardViewEnvelopeViewDriver";
+import "@patternfly/patternfly/patternfly.css";
+
+export interface CustomDashboardViewEnvelopeViewApi {
+  initialize: (dashboardName: string, targetOrigin: string) => void;
+}
+
+interface Props {
+  channelApi: MessageBusClientApi<CustomDashboardViewChannelApi>;
+}
+
+export const CustomDashboardViewEnvelopeView = React.forwardRef<CustomDashboardViewEnvelopeViewApi, Props>(
+  (props, forwardedRef) => {
+    const [isEnvelopeConnectedToChannel, setEnvelopeConnectedToChannel] = useState<boolean>(false);
+
+    const [customDashboardName, setCustomDashboardName] = useState<string>();
+    const [targetOrigin, setTargetOrigin] = useState<string>();
+
+    useImperativeHandle(
+      forwardedRef,
+      () => ({
+        initialize: (dashboardName: string, targetOrigin: string) => {
+          setEnvelopeConnectedToChannel(true);
+          setCustomDashboardName(dashboardName);
+          setTargetOrigin(targetOrigin);
+        },
+      }),
+      []
+    );
+    return (
+      <>
+        {customDashboardName && customDashboardName != "undefined" && (
+          <CustomDashboardView
+            isEnvelopeConnectedToChannel={isEnvelopeConnectedToChannel}
+            driver={new CustomDashboardViewEnvelopeViewDriver(props.channelApi)}
+            customDashboardName={customDashboardName}
+            targetOrigin={targetOrigin}
+          />
+        )}
+      </>
+    );
+  }
+);
+
+export default CustomDashboardViewEnvelopeView;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeView.tsx
@@ -57,7 +57,7 @@ export const CustomDashboardViewEnvelopeView = React.forwardRef<CustomDashboardV
             isEnvelopeConnectedToChannel={isEnvelopeConnectedToChannel}
             driver={new CustomDashboardViewEnvelopeViewDriver(props.channelApi)}
             customDashboardName={customDashboardName}
-            targetOrigin={targetOrigin}
+            targetOrigin={targetOrigin!}
           />
         )}
       </>

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeViewDriver.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/CustomDashboardViewEnvelopeViewDriver.ts
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { MessageBusClientApi } from "@kie-tools-core/envelope-bus/dist/api";
+import { CustomDashboardViewChannelApi, CustomDashboardViewDriver } from "../api";
+
+/**
+ * Implementation of CustomDashboardViewEnvelopeViewDriver that delegates calls to the channel Api
+ */
+export default class CustomDashboardViewEnvelopeViewDriver implements CustomDashboardViewDriver {
+  constructor(private readonly channelApi: MessageBusClientApi<CustomDashboardViewChannelApi>) {}
+
+  getCustomDashboardContent(name: string): Promise<string> {
+    return this.channelApi.requests.customDashboardView__getCustomDashboardView(name);
+  }
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/components/CustomDashboardView/CustomDashboardView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/components/CustomDashboardView/CustomDashboardView.tsx
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useRef, useState } from "react";
+import { OUIAProps, componentOuiaProps } from "@kie-tools/runtime-tools-components/dist/ouiaTools";
+import { CustomDashboardViewDriver } from "../../../api/CustomDashboardViewDriver";
+import { ServerErrors } from "@kie-tools/runtime-tools-components/dist/components/ServerErrors";
+import { Card } from "@patternfly/react-core/dist/js/components/Card";
+import { Bullseye } from "@patternfly/react-core/dist/js/layouts/Bullseye";
+
+export interface CustomDashboardViewProps {
+  isEnvelopeConnectedToChannel: boolean;
+  driver: CustomDashboardViewDriver;
+  customDashboardName: string;
+  targetOrigin: string;
+}
+
+const CustomDashboardView: React.FC<CustomDashboardViewProps & OUIAProps> = ({
+  isEnvelopeConnectedToChannel,
+  driver,
+  ouiaId,
+  customDashboardName,
+  targetOrigin,
+  ouiaSafe,
+}) => {
+  const ref = useRef(null);
+  const [dashboardContent, setDashboardContent] = useState<string>();
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [isError, setError] = useState<boolean>(false);
+  const [isReady, setReady] = useState<boolean>(false);
+  driver
+    .getCustomDashboardContent(customDashboardName)
+    .then((value) => setDashboardContent(value))
+    .catch((error) => {
+      setError(true);
+      setErrorMessage(error.message);
+    });
+
+  window.addEventListener("message", (e) => {
+    if (e.origin !== targetOrigin) {
+      return;
+    }
+    if (e.data == "ready") {
+      setReady(true);
+    }
+  });
+
+  useEffect(() => {
+    if (isReady) {
+      ref.current.contentWindow.postMessage(dashboardContent, null);
+    }
+  });
+
+  return (
+    <>
+      {isError ? (
+        <>
+          {isEnvelopeConnectedToChannel && (
+            <Card className="kogito-custom-dashboard-view-__card-size">
+              <Bullseye>
+                <ServerErrors error={errorMessage} variant="large" />
+              </Bullseye>
+            </Card>
+          )}
+        </>
+      ) : (
+        <iframe
+          ref={ref}
+          id="db"
+          src="resources/webapp/custom-dashboard-view/dashbuilder/index.html"
+          style={{ width: "100%", height: "100%", padding: "10px" }}
+          {...componentOuiaProps(ouiaId, "customDashboard-view", ouiaSafe)}
+        />
+      )}
+    </>
+  );
+};
+
+export default CustomDashboardView;

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/components/CustomDashboardView/CustomDashboardView.tsx
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/components/CustomDashboardView/CustomDashboardView.tsx
@@ -39,7 +39,7 @@ const CustomDashboardView: React.FC<CustomDashboardViewProps & OUIAProps> = ({
   targetOrigin,
   ouiaSafe,
 }) => {
-  const ref = useRef(null);
+  const ref = useRef<HTMLIFrameElement>(null);
   const [dashboardContent, setDashboardContent] = useState<string>();
   const [errorMessage, setErrorMessage] = useState<string>();
   const [isError, setError] = useState<boolean>(false);
@@ -62,8 +62,8 @@ const CustomDashboardView: React.FC<CustomDashboardViewProps & OUIAProps> = ({
   });
 
   useEffect(() => {
-    if (isReady) {
-      ref.current.contentWindow.postMessage(dashboardContent, null);
+    if (isReady && ref) {
+      ref.current?.contentWindow?.postMessage(dashboardContent, "");
     }
   });
 

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/components/CustomDashboardView/styles.css
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/components/CustomDashboardView/styles.css
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.kogito-custom-dashboard-view-__card-size {
+  height: 100%;
+}

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/envelope/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./CustomDashboardViewEnvelope";

--- a/packages/runtime-tools-enveloped-components/src/customDashboardView/index.ts
+++ b/packages/runtime-tools-enveloped-components/src/customDashboardView/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./api";
+export * from "./embedded";
+export * from "./envelope";


### PR DESCRIPTION
**Jira:** https://issues.redhat.com/browse/KOGITO-9956

**Description:**
Copy all packages related to the custom dashboards feature to the appropriate runtime-tools-* package in kie-tools. This will later be used in the soon to be migrated Dev UI extension.

Migrated in this PR:
- customDashboardView
- customDashboardList